### PR TITLE
Add DOUBLE_IEEE754 to zabbix.conf.php template

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -16,6 +16,7 @@ class zabbix::web (
   $dbname             = 'zabbix',
   $dbuser             = 'zabbix',
   $dbpass             = 'secret',
+  $double             = false,
   $server_host        = 'localhost',
   $server_port        = '10051',
   $server_name        = '',

--- a/templates/zabbix.conf.php.erb
+++ b/templates/zabbix.conf.php.erb
@@ -10,6 +10,7 @@ $DB["USER"]		= '<%= @dbuser %>';
 $DB["PASSWORD"]		= '<%= @dbpass %>';
 // SCHEMA is relevant only for IBM_DB2 database
 $DB["SCHEMA"]		= '';
+$DB["DOUBLE_IEEE754"]		= '<%= @double %>';
 
 $ZBX_SERVER		= '<%= @server_host %>';
 $ZBX_SERVER_PORT	= '<%= @server_port %>';


### PR DESCRIPTION
Add $DB["DOUBLE_IEEE754"] to zabbix.conf.php template. Defaults as false.