### PR TITLE
agent 2 variant patch

### DIFF
--- a/manifests/agent/amavisd.pp
+++ b/manifests/agent/amavisd.pp
@@ -6,7 +6,9 @@
 #   include zabbix::agent::amavisd
 #
 class zabbix::agent::amavisd (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
@@ -24,13 +26,13 @@ class zabbix::agent::amavisd (
     }
   }
 
-  file { "${dir_zabbix_agentd_confd}/amavisd.conf" :
+  file { "${conf_dir}/amavisd.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/amavisd.conf.erb'),
-    notify  => Service['zabbix-agent'],
-    require => Package['zabbix-agent'],
+    notify  => Service[$agent_service],
+    require => Package[$agent_package],
   }
 
   file { "${dir_zabbix_agent_libdir}/amavisd.pl" :
@@ -39,7 +41,7 @@ class zabbix::agent::amavisd (
     group  => root,
     mode   => '0755',
     source => 'puppet:///modules/zabbix/agent/amavisd.pl',
-    notify => Service['zabbix-agent'],
+    notify => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/check_amavis.pl" :
@@ -48,7 +50,7 @@ class zabbix::agent::amavisd (
     group  => root,
     mode   => '0755',
     source => 'puppet:///modules/zabbix/agent/check_amavis.pl',
-    notify => Service['zabbix-agent'],
+    notify => Service[$agent_service],
   }
 
 }

--- a/manifests/agent/apache.pp
+++ b/manifests/agent/apache.pp
@@ -4,16 +4,18 @@
 # This module installs zabbix apache plugin
 #
 class zabbix::agent::apache (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
-  $status_address = 'localhost'
+  $status_address          = 'localhost'
 ) inherits zabbix::agent {
 
   package { 'curl':
     ensure => present,
   }
 
-  file { "${dir_zabbix_agentd_confd}/apache2.conf" :
+  file { "${conf_dir}/apache2.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
@@ -21,9 +23,9 @@ class zabbix::agent::apache (
     content => template('zabbix/agent/apache2.conf.erb'),
     require => [
       File["${dir_zabbix_agent_libdir}/apache2.pl"],
-      Package['zabbix-agent'],
+      Package[$agent_package],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/apache2.pl" :
@@ -35,7 +37,7 @@ class zabbix::agent::apache (
     require => [
       Package['curl'],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
 }

--- a/manifests/agent/beegfs.pp
+++ b/manifests/agent/beegfs.pp
@@ -4,21 +4,23 @@
 # This module installs Zabbix BeeGFS sensor
 #
 class zabbix::agent::beegfs (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/beegfs.conf" :
+  file { "${conf_dir}/beegfs.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     source  =>  'puppet:///modules/zabbix/agent/beegfs/beegfs.conf',
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/zabbix-beegfs.pl"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/zabbix-beegfs.pl" :
@@ -28,7 +30,7 @@ class zabbix::agent::beegfs (
     mode    => '0755',
     source  => 'puppet:///modules/zabbix/agent/beegfs/zabbix-beegfs.pl',
     require =>  [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       Package['perl-JSON'],
     ],
   }

--- a/manifests/agent/bind.pp
+++ b/manifests/agent/bind.pp
@@ -6,7 +6,9 @@
 #   include zabbix::agent::bind
 #
 class zabbix::agent::bind (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
@@ -24,13 +26,13 @@ class zabbix::agent::bind (
     require_password => false,
   }
 
-  file { "${dir_zabbix_agentd_confd}/bind.conf" :
+  file { "${conf_dir}/bind.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/bind.conf.erb'),
-    notify  => Service['zabbix-agent'],
-    require => Package['zabbix-agent'],
+    notify  => Service[$agent_service],
+    require => Package[$agent_package],
   }
 
   file { "${dir_zabbix_agent_libdir}/bind.pl" :
@@ -39,7 +41,7 @@ class zabbix::agent::bind (
     group   => root,
     mode    => '0755',
     source  => 'puppet:///modules/zabbix/agent/bind.pl',
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => [
       ::Sudoers::Allowed_command['zabbix_rndc'],
       ::Sudoers::Allowed_command['zabbix_named'],

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -5,23 +5,25 @@
 # directory.
 define zabbix::agent::config (
   $settings,
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
-  $notify_service         = true,
+  $conf_dir       = $::zabbix::agent::conf_dir,
+  $agent_service  = $::zabbix::agent::service_state,
+  $agent_package  = $::zabbix::agent::agent_package,
+  $notify_service = true,
 ) {
   include ::zabbix::agent
 
   $service_to_notify = $notify_service ? {
     default => undef,
-    true    => Service['zabbix-agent'],
+    true    => Service[$agent_service],
   }
 
-  file { "${dir_zabbix_agentd_confd}/${name}.conf":
+  file { "${conf_dir}/${name}.conf":
     ensure  => file,
     content => template('zabbix/custom.conf.erb'),
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    require => File[$dir_zabbix_agentd_confd],
+    require => File[$conf_dir],
     notify  => $service_to_notify,
   }
 

--- a/manifests/agent/dnsmasq.pp
+++ b/manifests/agent/dnsmasq.pp
@@ -5,16 +5,18 @@
 #
 class zabbix::agent::dnsmasq (
   $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/dnsmasq.conf" :
+  file { "${conf_dir}/dnsmasq.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/dnsmasq.conf.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => [ Package['dnsmasq'] ],
   }
 

--- a/manifests/agent/dovecot.pp
+++ b/manifests/agent/dovecot.pp
@@ -6,19 +6,21 @@
 #   include zabbix::agent::dovecot
 #
 class zabbix::agent::dovecot (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
   include zabbix::agent::logtail
 
-  file { "${dir_zabbix_agentd_confd}/dovecot.conf" :
+  file { "${conf_dir}/dovecot.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/dovecot.conf.erb'),
-    notify  => Service['zabbix-agent'],
-    require => Package['zabbix-agent'],
+    notify  => Service[$agent_service],
+    require => Package[$agent_package],
   }
 
   file { "${dir_zabbix_agent_libdir}/dovecot.pl" :
@@ -27,7 +29,7 @@ class zabbix::agent::dovecot (
     group  => root,
     mode   => '0755',
     source => 'puppet:///modules/zabbix/agent/dovecot.pl',
-    notify => Service['zabbix-agent'],
+    notify => Service[$agent_service],
   }
 
 }

--- a/manifests/agent/elasticsearch.pp
+++ b/manifests/agent/elasticsearch.pp
@@ -4,21 +4,23 @@
 # This module installs ElasticSearch sensor
 #
 class zabbix::agent::elasticsearch (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/elasticsearch.conf" :
+  file { "${conf_dir}/elasticsearch.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/elasticsearch.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/elasticsearch.rb"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/elasticsearch.rb" :

--- a/manifests/agent/glpi.pp
+++ b/manifests/agent/glpi.pp
@@ -4,7 +4,9 @@
 # This module installs Zabbix GLPI sensor
 #
 class zabbix::agent::glpi (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
   $script_source           = 'puppet:///modules/zabbix/agent/glpi/glpi2zabbix.py',
   $glpi_url                = 'https://localhost/glpi',
@@ -22,7 +24,7 @@ class zabbix::agent::glpi (
     mode    => '0750',
     content => template('zabbix/agent/glpi2zabbix.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/glpi2zabbix.py"],
       Package['pyzabbix'],
     ],

--- a/manifests/agent/gpu.pp
+++ b/manifests/agent/gpu.pp
@@ -4,23 +4,25 @@
 # This module installs Zabbix GPU sensor
 #
 class zabbix::agent::gpu (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/gpu.conf" :
+  file { "${conf_dir}/gpu.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/gpu.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/get_gpu_info"],
       File["${dir_zabbix_agent_libdir}/get_gpus_info.sh"],
       Package['python35u'],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/get_gpu_info" :

--- a/manifests/agent/ib.pp
+++ b/manifests/agent/ib.pp
@@ -4,7 +4,9 @@
 # This module installs Zabbix Infiniband sensor
 #
 class zabbix::agent::ib (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
   $extended                = 1,
   $period                  = '',
@@ -17,18 +19,18 @@ class zabbix::agent::ib (
     comment          => 'Zabbix Infiniband sensor',
   }
 
-  file { "${dir_zabbix_agentd_confd}/ib.conf" :
+  file { "${conf_dir}/ib.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/ib.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       Package['infiniband-diags'],
       File["${dir_zabbix_agent_libdir}/zabbix-ib.pl"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/zabbix-ib.pl" :

--- a/manifests/agent/iptables.pp
+++ b/manifests/agent/iptables.pp
@@ -4,7 +4,9 @@
 # This module installs zabbix iptables plugin
 #
 class zabbix::agent::iptables (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
 ) inherits zabbix::agent {
 
   case $facts['os']['family'] {
@@ -22,7 +24,7 @@ class zabbix::agent::iptables (
   package { 'zabbix-agent_iptables':
     ensure  => present,
     name    => $plugin_package,
-    require => Package['zabbix-agent'],
+    require => Package[$agent_package],
   }
 
 }

--- a/manifests/agent/lld.pp
+++ b/manifests/agent/lld.pp
@@ -4,7 +4,9 @@
 # Adds some standard Low Level Discovery items
 #
 class zabbix::agent::lld (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
@@ -15,13 +17,13 @@ class zabbix::agent::lld (
     comment          => 'Zabbix LLD blockdev.',
   }
 
-  file { "${dir_zabbix_agentd_confd}/lld.conf" :
+  file { "${conf_dir}/lld.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/lld/lld.conf.erb'),
-    notify  => Service['zabbix-agent'],
-    require => Package['zabbix-agent'],
+    notify  => Service[$agent_service],
+    require => Package[$agent_package],
   }
 
   file { "${dir_zabbix_agent_libdir}/lld-blockdev" :
@@ -30,7 +32,7 @@ class zabbix::agent::lld (
     group   => root,
     mode    => '0755',
     source  => 'puppet:///modules/zabbix/agent/lld/lld-blockdev',
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => ::Sudoers::Allowed_command['zabbix_sudo_multipath'],
   }
 
@@ -40,6 +42,6 @@ class zabbix::agent::lld (
     group  => root,
     mode   => '0755',
     source => 'puppet:///modules/zabbix/agent/lld/lld-macro',
-    notify => Service['zabbix-agent'],
+    notify => Service[$agent_service],
   }
 }

--- a/manifests/agent/mailcheck.pp
+++ b/manifests/agent/mailcheck.pp
@@ -5,19 +5,21 @@
 #
 class zabbix::agent::mailcheck (
   $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
   $mail_host               = 'imap.srce.hr',
   $mail_username           = '',
   $mail_password           = '',
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/mailcheck.conf":
+  file { "${conf_dir}/mailcheck.conf":
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/mailcheck.conf.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     #require => [ Package['php-cli'] ],
   }
 

--- a/manifests/agent/mdraid.pp
+++ b/manifests/agent/mdraid.pp
@@ -4,7 +4,9 @@
 # This module installs zabbix mdraid sensor
 #
 class zabbix::agent::mdraid (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
@@ -15,16 +17,16 @@ class zabbix::agent::mdraid (
     comment          => 'Zabbix mdadm --detail listing',
   }
 
-  file { "${dir_zabbix_agentd_confd}/mdraid.conf" :
+  file { "${conf_dir}/mdraid.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/mdraid.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/check_mdraid"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/check_mdraid" :

--- a/manifests/agent/megacli.pp
+++ b/manifests/agent/megacli.pp
@@ -4,12 +4,14 @@
 # This module installs zabbix megacli plugin
 #
 class zabbix::agent::megacli (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir      = $::zabbix::agent::conf_dir,
+  $agent_service = $::zabbix::agent::service_state,
+  $agent_package = $::zabbix::agent::agent_package,
 ) inherits zabbix::agent {
 
   package { 'zabbix-agent_megacli':
     ensure  => present,
-    require => Package['zabbix-agent'],
+    require => Package[$agent_package],
   }
 
 }

--- a/manifests/agent/memcached.pp
+++ b/manifests/agent/memcached.pp
@@ -5,16 +5,18 @@
 #
 class zabbix::agent::memcached (
   $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/memcached.conf" :
+  file { "${conf_dir}/memcached.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/memcached.conf.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/memcached.pl" :
@@ -23,7 +25,7 @@ class zabbix::agent::memcached (
     group  => root,
     mode   => '0755',
     source => 'puppet:///modules/zabbix/agent/memcached.pl',
-    notify => Service['zabbix-agent'],
+    notify => Service[$agent_service],
   }
 
 }

--- a/manifests/agent/mysql.pp
+++ b/manifests/agent/mysql.pp
@@ -5,21 +5,23 @@
 #
 class zabbix::agent::mysql (
   $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
+  $conf_dir                = $::zabbix::agent::conf_dir,
 ) inherits zabbix::agent {
 
   package { 'zabbix-agent_mysql':
     ensure  => present,
-    require => Package['zabbix-agent'],
+    require => Package[$agent_package],
   }
 
-  file { "${dir_zabbix_agentd_confd}/mysql.conf" :
+  file { "${conf_dir}/mysql.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/mysql.conf.erb'),
     require => Package['zabbix-agent_mysql'],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
 }

--- a/manifests/agent/mysql/slave.pp
+++ b/manifests/agent/mysql/slave.pp
@@ -5,16 +5,18 @@
 #
 class zabbix::agent::mysql::slave (
   $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/mysql-slave.conf" :
+  file { "${conf_dir}/mysql-slave.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/mysql-slave.conf.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   mysql_user { 'zabbix@localhost':

--- a/manifests/agent/net_overruns.pp
+++ b/manifests/agent/net_overruns.pp
@@ -4,15 +4,17 @@
 # Adds items for network interface overruns items
 #
 class zabbix::agent::net_overruns (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/net_overruns.conf" :
+  file { "${conf_dir}/net_overruns.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     source  => 'puppet:///modules/zabbix/agent/net_overruns.conf',
-    notify  => Service['zabbix-agent'],
-    require => Package['zabbix-agent'],
+    notify  => Service[$agent_service],
+    require => Package[$agent_package],
   }
 }

--- a/manifests/agent/nfsclient.pp
+++ b/manifests/agent/nfsclient.pp
@@ -4,19 +4,21 @@
 # This module installs NFS client monitoring plugin
 #
 class zabbix::agent::nfsclient (
-  $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $options            = '',
+  $conf_dir           = $::zabbix::agent::conf_dir,
+  $agent_service      = $::zabbix::agent::service_state,
+  $agent_package      = $::zabbix::agent::agent_package,
   $dir_for_monitoring = $::zabbix::agent::dir_for_monitoring,
 ) inherits zabbix::agent {
 
     if $dir_for_monitoring {
-      file { "${dir_zabbix_agentd_confd}/nfsclient.conf":
+      file { "${conf_dir}/nfsclient.conf":
         ensure  => file,
         owner   => root,
         group   => root,
         mode    => '0644',
         content => template('zabbix/agent/nfsclient.conf.erb'),
-        notify  => Service['zabbix-agent'],
+        notify  => Service[$agent_service],
       }
     }
 

--- a/manifests/agent/ntp.pp
+++ b/manifests/agent/ntp.pp
@@ -4,7 +4,9 @@
 # This module installs zabbix ntp plugin
 #
 class zabbix::agent::ntp (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir      = $::zabbix::agent::conf_dir,
+  $agent_service = $::zabbix::agent::service_state,
+  $agent_package = $::zabbix::agent::agent_package,
 ) inherits zabbix::agent {
 
   case $facts['os']['family'] {
@@ -14,21 +16,21 @@ class zabbix::agent::ntp (
 
       case $facts['os']['release']['major'] {
         /^(8|9)/ : {
-          file { "${dir_zabbix_agentd_confd}/chrony.conf" :
+          file { "${conf_dir}/chrony.conf" :
             ensure  => file,
             owner   => root,
             group   => root,
             content => template('zabbix/agent/chrony.conf.erb'),
-            notify  => Service['zabbix-agent'],
+            notify  => Service[$agent_service],
           }
         }
         default: {
-          file { "${dir_zabbix_agentd_confd}/ntp.conf" :
+          file { "${conf_dir}/ntp.conf" :
             ensure  => file,
             owner   => root,
             group   => root,
             content => template('zabbix/agent/ntp.conf.erb'),
-            notify  => Service['zabbix-agent'],
+            notify  => Service[$agent_service],
           }
         }
       }
@@ -38,12 +40,12 @@ class zabbix::agent::ntp (
 
       $ntpq_bin = '/usr/bin/ntpq'
 
-      file { "${dir_zabbix_agentd_confd}/ntp.conf" :
+      file { "${conf_dir}/ntp.conf" :
         ensure  => file,
         owner   => root,
         group   => root,
         content => template('zabbix/agent/ntp.conf.erb'),
-        notify  => Service['zabbix-agent'],
+        notify  => Service[$agent_service],
       }
     }
 

--- a/manifests/agent/opcache.pp
+++ b/manifests/agent/opcache.pp
@@ -4,24 +4,26 @@
 # This module installs Zabbix PHP opcache sensor
 #
 class zabbix::agent::opcache (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
   $host                    = 'localhost',
 ) inherits zabbix::agent {
 
   include apache
 
-  file { "${dir_zabbix_agentd_confd}/opcache.conf" :
+  file { "${conf_dir}/opcache.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/opcache.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/zabbix-opcache.pl"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/zabbix-opcache.pl" :
@@ -31,7 +33,7 @@ class zabbix::agent::opcache (
     mode    => '0755',
     source  => 'puppet:///modules/zabbix/agent/opcache/zabbix-opcache.pl',
     require =>  [
-      Package['zabbix-agent'],
+      Package[$agent_package],
     ],
   }
 
@@ -42,10 +44,10 @@ class zabbix::agent::opcache (
     mode    => '0644',
     content => template('zabbix/agent/opcache_stats.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/zabbix-opcache.pl"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/opcache_stats.php" :

--- a/manifests/agent/ossec.pp
+++ b/manifests/agent/ossec.pp
@@ -4,8 +4,10 @@
 # This module installs zabbix ossec/wazuh sensor
 #
 class zabbix::agent::ossec (
-  $server_package = 'wazuh-manager',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $server_package          = 'wazuh-manager',
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
@@ -16,12 +18,12 @@ class zabbix::agent::ossec (
     comment          => 'Zabbix sensor for monitoring OSSEC/Wazuh agents.',
   }
 
-  file { "${dir_zabbix_agentd_confd}/ossec.conf":
+  file { "${conf_dir}/ossec.conf":
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/ossec.conf.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => Package[$server_package],
   }
 

--- a/manifests/agent/phpfpm.pp
+++ b/manifests/agent/phpfpm.pp
@@ -4,7 +4,9 @@
 # This module installs Zabbix php-fpm sensor
 #
 class zabbix::agent::phpfpm (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
   $php_fpm_sock            = undef,
 ) inherits zabbix::agent {
@@ -59,18 +61,18 @@ class zabbix::agent::phpfpm (
     name   => $cgi_fcgi,
   }
 
-  file { "${dir_zabbix_agentd_confd}/php-fpm.conf" :
+  file { "${conf_dir}/php-fpm.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/php-fpm.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/php-fpm.sh"],
       Package['cgi-fcgi'],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/php-fpm.sh" :

--- a/manifests/agent/pkgupgrades.pp
+++ b/manifests/agent/pkgupgrades.pp
@@ -4,34 +4,36 @@
 # This module installs zabbix plugin for counting pending upgrades
 #
 class zabbix::agent::pkgupgrades (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir      = $::zabbix::agent::conf_dir,
+  $agent_service = $::zabbix::agent::service_state,
+  $agent_package = $::zabbix::agent::agent_package,
 ) inherits zabbix::agent {
 
   case $facts['os']['family'] {
     default: {}
     /(RedHat|redhat|amazon)/: {
-      file { "${dir_zabbix_agentd_confd}/pkgupgrades.conf" :
+      file { "${conf_dir}/pkgupgrades.conf" :
         ensure  => file,
         owner   => root,
         group   => root,
         content => template('zabbix/agent/pkgupgrades-rhel.conf.erb'),
-        notify  => Service['zabbix-agent'],
+        notify  => Service[$agent_service],
       }
-      
+
       ::sudoers::allowed_command { 'zabbix_yum':
-        command          => "/usr/bin/yum -y -q check-update",
+        command          => '/usr/bin/yum -y -q check-update',
         user             => 'zabbix',
         require_password => false,
         comment          => 'Zabbix sensor for monitoring packages pending upgrade.',
       }
     }
     /(Debian|debian|Ubuntu|ubuntu)/: {
-      file { "${dir_zabbix_agentd_confd}/pkgupgrades.conf" :
+      file { "${conf_dir}/pkgupgrades.conf" :
         ensure  => file,
         owner   => root,
         group   => root,
         content => template('zabbix/agent/pkgupgrades-debian.conf.erb'),
-        notify  => Service['zabbix-agent'],
+        notify  => Service[$agent_service],
       }
     }
   }

--- a/manifests/agent/postfix.pp
+++ b/manifests/agent/postfix.pp
@@ -6,7 +6,9 @@
 #   include zabbix::agent::postfix
 #
 class zabbix::agent::postfix (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
@@ -31,13 +33,13 @@ class zabbix::agent::postfix (
     require_password => false,
   }
 
-  file { "${dir_zabbix_agentd_confd}/postfix.conf" :
+  file { "${conf_dir}/postfix.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/postfix.conf.erb'),
-    notify  => Service['zabbix-agent'],
-    require => Package['zabbix-agent'],
+    notify  => Service[$agent_service],
+    require => Package[$agent_package],
   }
 
   file { "${dir_zabbix_agent_libdir}/postfix.pl" :
@@ -46,7 +48,7 @@ class zabbix::agent::postfix (
     group   => root,
     mode    => '0755',
     source  => 'puppet:///modules/zabbix/agent/postfix.pl',
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => ::Sudoers::Allowed_command['zabbix_postfix'],
   }
 

--- a/manifests/agent/proxy.pp
+++ b/manifests/agent/proxy.pp
@@ -5,7 +5,9 @@
 #
 class zabbix::agent::proxy (
   $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
@@ -16,13 +18,13 @@ class zabbix::agent::proxy (
     comment          => 'Zabbix sensor for monitoring proxy.',
   }
 
-  file { "${dir_zabbix_agentd_confd}/proxy.conf" :
+  file { "${conf_dir}/proxy.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/proxy.conf.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => ::Sudoers::Allowed_command['zabbix_proxy'],
   }
 
@@ -32,7 +34,7 @@ class zabbix::agent::proxy (
     group   => root,
     mode    => '0755',
     source  => 'puppet:///modules/zabbix/agent/proxy.pl',
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => ::Sudoers::Allowed_command['zabbix_proxy'],
   }
 

--- a/manifests/agent/puppet_agent.pp
+++ b/manifests/agent/puppet_agent.pp
@@ -5,7 +5,9 @@
 #
 class zabbix::agent::puppet_agent (
 
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 
 ) inherits zabbix::agent {
@@ -17,13 +19,13 @@ class zabbix::agent::puppet_agent (
     comment          => 'Zabbix sensor for monitoring Puppet agent.',
   }
 
-  file { "${dir_zabbix_agentd_confd}/puppet_agent.conf" :
+  file { "${conf_dir}/puppet_agent.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/puppet_agent.conf.erb'),
-    notify  => Service['zabbix-agent'],
-    require => Package['zabbix-agent'],
+    notify  => Service[$agent_service],
+    require => Package[$agent_package],
   }
 
   file { "${dir_zabbix_agent_libdir}/puppet_agent" :
@@ -32,7 +34,7 @@ class zabbix::agent::puppet_agent (
     group   => root,
     mode    => '0755',
     content => template('zabbix/agent/puppet_agent.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => ::Sudoers::Allowed_command['zabbix_puppet_agent'],
   }
 

--- a/manifests/agent/rabbitmq.pp
+++ b/manifests/agent/rabbitmq.pp
@@ -4,7 +4,9 @@
 # This module installs RabbitMQ sensor
 #
 class zabbix::agent::rabbitmq (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
   $username                = 'use_hiera',
   $password                = 'use_hiera',
@@ -15,21 +17,21 @@ class zabbix::agent::rabbitmq (
   $senderhostname          = $facts['networking']['fqdn'],
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/rabbitmq.conf" :
+  file { "${conf_dir}/rabbitmq.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/rabbitmq.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/api.py"],
       File["${dir_zabbix_agent_libdir}/list_rabbit_nodes.sh"],
       File["${dir_zabbix_agent_libdir}/list_rabbit_queues.sh"],
       File["${dir_zabbix_agent_libdir}/rabbitmq-status.sh"],
       File["${dir_zabbix_agent_libdir}/.rab.auth"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/api.py" :

--- a/manifests/agent/sge.pp
+++ b/manifests/agent/sge.pp
@@ -4,23 +4,25 @@
 # This module installs Zabbix SGE sensor
 #
 class zabbix::agent::sge (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/sge.conf" :
+  file { "${conf_dir}/sge.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/sge.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/sge.pl"],
       File["${dir_zabbix_agent_libdir}/sge-lld.pl"],
       Package['perl-JSON'],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   package { 'perl-JSON':

--- a/manifests/agent/ssh.pp
+++ b/manifests/agent/ssh.pp
@@ -4,8 +4,10 @@
 # This module installs zabbix ssh plugin
 #
 class zabbix::agent::ssh (
-  $options                 = '',
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $options       = '',
+  $conf_dir      = $::zabbix::agent::conf_dir,
+  $agent_service = $::zabbix::agent::service_state,
+  $agent_package = $::zabbix::agent::agent_package,
 ) inherits zabbix::agent {
 
   case $facts['os']['family'] {
@@ -34,12 +36,12 @@ class zabbix::agent::ssh (
     comment          => 'Zabbix sensor for monitoring SSH.',
   }
 
-  file { "${dir_zabbix_agentd_confd}/ssh.conf" :
+  file { "${conf_dir}/ssh.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     content => template('zabbix/agent/ssh.conf.erb'),
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
     require => ::Sudoers::Allowed_command['zabbix_ssh'],
   }
 

--- a/manifests/agent/tcp.pp
+++ b/manifests/agent/tcp.pp
@@ -4,18 +4,20 @@
 # Add module for TCP connections
 #
 class zabbix::agent::tcp (
-  $dir_zabbix_agentd_confd  = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                 = $::zabbix::agent::conf_dir,
+  $agent_service            = $::zabbix::agent::service_state,
+  $agent_package            = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_modules = $::zabbix::agent::dir_zabbix_agent_modules,
   $module                   = "puppet:///modules/zabbix/agent/modules/${facts[os][family]}/${facts[os][release][major]}/tcp_count.so"
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/tcp.conf" :
+  file { "${conf_dir}/tcp.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     source  => 'puppet:///modules/zabbix/agent/tcp.conf',
-    notify  => Service['zabbix-agent'],
-    require => [ Package['zabbix-agent'], File["${dir_zabbix_agent_modules}/tcp_count.so"] ],
+    notify  => Service[$agent_service],
+    require => [ Package[$agent_package], File["${dir_zabbix_agent_modules}/tcp_count.so"] ],
   }
 
   file { "${dir_zabbix_agent_modules}/tcp_count.so" :
@@ -24,6 +26,6 @@ class zabbix::agent::tcp (
     group  => root,
     mode   => '0644',
     source => $module,
-    notify => Service['zabbix-agent'],
+    notify => Service[$agent_service],
   }
 }

--- a/manifests/agent/tomcatdir.pp
+++ b/manifests/agent/tomcatdir.pp
@@ -4,21 +4,23 @@
 # This module installs Tomcat Git Repo sensor
 #
 class zabbix::agent::tomcatdir (
-  $dir_zabbix_agentd_confd = $::zabbix::agent::dir_zabbix_agentd_confd,
+  $conf_dir                = $::zabbix::agent::conf_dir,
+  $agent_service           = $::zabbix::agent::service_state,
+  $agent_package           = $::zabbix::agent::agent_package,
   $dir_zabbix_agent_libdir = $::zabbix::agent::dir_zabbix_agent_libdir,
 ) inherits zabbix::agent {
 
-  file { "${dir_zabbix_agentd_confd}/tomcatdir.conf" :
+  file { "${conf_dir}/tomcatdir.conf" :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
     content => template('zabbix/agent/tomcatdir.conf.erb'),
     require => [
-      Package['zabbix-agent'],
+      Package[$agent_package],
       File["${dir_zabbix_agent_libdir}/tomcat-dir.jar"],
     ],
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$agent_service],
   }
 
   file { "${dir_zabbix_agent_libdir}/tomcat-dir.jar" :

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,18 @@ class zabbix::params {
   $agent_file_mode      = '0644'
   $agent_purge_conf_dir = false
 
+  # zabbix agent 2 specific settings
+  $agent2_package             = 'zabbix-agent2'
+  $agent2_service             = 'zabbix-agent2'
+  $dir_zabbix_agent2_d        = '/etc/zabbix/zabbix_agent2.d'
+  $file_zabbix_agent2_conf    = '/etc/zabbix/zabbix_agent2.conf'
+  $dir_zabbix_agent2_pluginsd = '/etc/zabbix/zabbix_agent2.d/plugins.d'
+  $zabbix_agent2_logfile      = '/var/log/zabbix/zabbix_agent2.log'
+  $zabbix_agent2_pidfile      = '/var/run/zabbix/zabbix_agent2.pid'
+
+  # zabbix repo conf_dir location
+  $dir_zabbix_agentd_d = '/etc/zabbix/zabbix_agentd.d'
+
   # module specific settings (proxy)
   $proxy_file_owner     = 'root'
   $proxy_file_group     = 'zabbix'
@@ -52,7 +64,6 @@ class zabbix::params {
       $agent_status               = 'enabled'
       $file_zabbix_agentd_conf    = '/etc/zabbix/zabbix_agentd.conf'
       $dir_zabbix_agentd_confd    = '/etc/zabbix/zabbix_agentd.d'
-      $dir_zabbix_agent2_pluginsd = '/etc/zabbix/zabbix_agent2.d/plugins.d'
       $dir_zabbix_agent_libdir    = '/usr/lib/zabbix/agent'
       $dir_zabbix_agent_modules   = '/usr/lib/zabbix/agent/modules'
       $zabbix_agentd_logfile      = '/var/log/zabbix/zabbix_agentd.log'
@@ -102,7 +113,6 @@ class zabbix::params {
       $agent_status               = 'enabled'
       $file_zabbix_agentd_conf    = '/etc/zabbix/zabbix_agentd.conf'
       $dir_zabbix_agentd_confd    = '/etc/zabbix/zabbix_agentd.d'
-      $dir_zabbix_agent2_pluginsd = '/etc/zabbix/zabbix_agent2.d/plugins.d'
       $dir_zabbix_agent_libdir    = '/usr/libexec/zabbix-agent'
       $dir_zabbix_agent_modules   = '/usr/libexec/zabbix-agent/modules'
       $zabbix_agentd_logfile      = '/var/log/zabbix/zabbix_agentd.log'
@@ -157,7 +167,6 @@ class zabbix::params {
       $agent_status               = 'enabled'
       $file_zabbix_agentd_conf    = '/etc/zabbix/zabbix_agentd.conf'
       $dir_zabbix_agentd_confd    = '/etc/zabbix/zabbix_agentd.conf.d'
-      $dir_zabbix_agent2_pluginsd = '/etc/zabbix/zabbix_agent2.d/plugins.d'
       $dir_zabbix_agent_libdir    = '/usr/lib/zabbix-agent'
       $dir_zabbix_agent_modules   = '/usr/lib/zabbix-agent/modules'
       $zabbix_agentd_logfile      = '/var/log/zabbix-agent/zabbix_agentd.log'

--- a/templates/zabbix20_agentd.conf.erb
+++ b/templates/zabbix20_agentd.conf.erb
@@ -10,7 +10,7 @@
 # Default:
 # PidFile=/tmp/zabbix_agentd.pid
 
-PidFile=<%= @zabbix_agent_pidfile %>
+PidFile=<%= @agent_pidfile %>
 
 ### Option: LogFile
 #	Name of log file.
@@ -20,7 +20,7 @@ PidFile=<%= @zabbix_agent_pidfile %>
 # Default:
 # LogFile=
 
-LogFile=<%= @zabbix_agentd_logfile %>
+LogFile=<%= @agent_logfile %>
 
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
@@ -217,7 +217,7 @@ Timeout=<%= @timeout %>
 # Default:
 # Include=
 
-Include=<%= @dir_zabbix_agentd_confd %>/
+Include=<%= @conf_dir %>/
 
 # Include=/usr/local/etc/zabbix_agentd.userparams.conf
 # Include=/usr/local/etc/zabbix_agentd.conf.d/

--- a/templates/zabbix32_agentd.conf.erb
+++ b/templates/zabbix32_agentd.conf.erb
@@ -29,7 +29,7 @@ PidFile=/var/run/zabbix/zabbix_agentd.pid
 # Default:
 # LogFile=
 
-LogFile=<%= @zabbix_agentd_logfile %>
+LogFile=<%= @agent_logfile %>
 
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
@@ -268,7 +268,7 @@ Timeout=<%= @timeout %>
 # Default:
 # Include=
 
-Include=<%= @dir_zabbix_agentd_confd %>/
+Include=<%= @conf_dir %>/
 
 # Include=/usr/local/etc/zabbix_agentd.userparams.conf
 # Include=/usr/local/etc/zabbix_agentd.conf.d/

--- a/templates/zabbix34_agentd.conf.erb
+++ b/templates/zabbix34_agentd.conf.erb
@@ -29,7 +29,7 @@ PidFile=/var/run/zabbix/zabbix_agentd.pid
 # Default:
 # LogFile=
 
-LogFile=<%= @zabbix_agentd_logfile %>
+LogFile=<%= @agent_logfile %>
 
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
@@ -270,7 +270,7 @@ Timeout=<%= @timeout %>
 # Default:
 # Include=
 
-Include=<%= @dir_zabbix_agentd_confd %>/
+Include=<%= @conf_dir %>/
 
 # Include=/usr/local/etc/zabbix_agentd.userparams.conf
 # Include=/usr/local/etc/zabbix_agentd.conf.d/

--- a/templates/zabbix40_agentd.conf.erb
+++ b/templates/zabbix40_agentd.conf.erb
@@ -29,7 +29,7 @@ PidFile=/var/run/zabbix/zabbix_agentd.pid
 # Default:
 # LogFile=
 
-LogFile=<%= @zabbix_agentd_logfile %>
+LogFile=<%= @agent_logfile %>
 
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
@@ -271,7 +271,7 @@ Timeout=<%= @timeout %>
 # Default:
 # Include=
 
-Include=<%= @dir_zabbix_agentd_confd %>/
+Include=<%= @conf_dir %>/
 
 # Include=/usr/local/etc/zabbix_agentd.userparams.conf
 # Include=/usr/local/etc/zabbix_agentd.conf.d/

--- a/templates/zabbix_agent2.conf.erb
+++ b/templates/zabbix_agent2.conf.erb
@@ -10,7 +10,7 @@
 # Default:
 # PidFile=/tmp/zabbix_agent2.pid
 
-PidFile=<%= @zabbix_agent_pidfile %>
+PidFile=<%= @agent_pidfile %>
 
 ### Option: LogType
 #	Specifies where log messages are written to:
@@ -29,7 +29,7 @@ PidFile=<%= @zabbix_agent_pidfile %>
 # Default:
 # LogFile=/tmp/zabbix_agent2.log
 
-LogFile=<%= @zabbix_agentd_logfile %>
+LogFile=<%= @agent_logfile %>
 
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
@@ -286,7 +286,7 @@ Timeout=<%= @timeout %>
 # Default:
 # Include=
 
-Include=<%= @dir_zabbix_agentd_confd %>/*.conf
+Include=<%= @conf_dir %>/*.conf
 
 # Include=/usr/local/etc/zabbix_agent2.userparams.conf
 # Include=/usr/local/etc/zabbix_agent2.conf.d/

--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -8,7 +8,7 @@
 #
 # Mandatory: no
 # Default:
-PidFile=<%= @zabbix_agent_pidfile %>
+PidFile=<%= @agent_pidfile %>
 
 ### Option: LogFile
 #	Name of log file.
@@ -17,7 +17,7 @@ PidFile=<%= @zabbix_agent_pidfile %>
 # Mandatory: no
 # Default:
 # LogFile=
-LogFile=<%= @zabbix_agentd_logfile %>
+LogFile=<%= @agent_logfile %>
 
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
@@ -241,7 +241,7 @@ Timeout=<%= @timeout %>
 
 # Include=/etc/zabbix_agentd.userparams.conf
 # Include=/etc/zabbix_agentd.conf.d/
-Include=<%= @dir_zabbix_agentd_confd %>/
+Include=<%= @conf_dir %>/
 
 ####### USER-DEFINED MONITORED PARAMETERS #######
 


### PR DESCRIPTION
Offers a choice between Zabbix agent variants. 

On Debian/Ubuntu family allows selection of agent configuration directory from either Debian native packages or upstream Zabbix agent packages for Zabbix agent.